### PR TITLE
chore: update CI, Docker, and Go dependencies

### DIFF
--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -18,15 +18,31 @@ env:
   IMAGE_NAME: image
 
 jobs:
+  # Run tests for every push and pull request.
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Run tests
+        run: go test ./...
+
   # Push image to GitHub Package Registry.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
 
+    needs: test
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build image
         run: docker build . --file Dockerfile --tag image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:alpine as builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /app
 COPY . .
 
 RUN go build -o postCollector main.go
 
-FROM alpine
+FROM alpine:3.22
 
 COPY --from=builder /app/postCollector /postCollector
 
-CMD /postCollector
+CMD ["/postCollector"]
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module postCollector
 
-go 1.13
+go 1.26
 
-require (
-	github.com/gorilla/mux v1.7.4
-	github.com/stretchr/testify v1.6.0
-)
+require github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,2 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
-github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
-github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=


### PR DESCRIPTION
Updates outdated dependencies across CI, Docker, and Go modules.

## Changes

**GitHub Actions** (`.github/workflows/dockerpush.yml`)
- Bump `actions/checkout@v2` → `@v4` (v2 runs on the EOL Node 16 runtime)
- Add a `test` job (`actions/setup-go@v5` + `go test ./...`) that runs on every push and PR
- Gate the `push` job behind `needs: test` so the image only ships if tests pass

**Dockerfile**
- Pin `golang:alpine` → `golang:1.26-alpine` and `alpine` → `alpine:3.22` (were floating tags)
- Uppercase `AS` and switch to exec-form `CMD` for proper OS-signal handling

**Go modules** (`go.mod`)
- `go 1.13` → `1.26` (matches the pinned Docker/CI versions)
- `gorilla/mux v1.7.4` → `v1.8.1`
- Drop unused `testify` dependency (nothing imports it; `main_test.go` uses only the stdlib)

## Verification
- `go test ./...` passes
- `go build` succeeds
- `docker build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)